### PR TITLE
kill_close_wait_connections.pl ipv6 dirty fix

### DIFF
--- a/kill_close_wait_connections.pl
+++ b/kill_close_wait_connections.pl
@@ -9,7 +9,7 @@ use NetPacket::TCP;
 use POSIX qw(setsid);
 use warnings;
 
-open(my $CONNECTIONS_WAIT, "netstat -tulnap | grep CLOSE_WAIT | awk '{print \$4,\$5}' | sed 's/:/ /g' |") || die "Failed: $!\n";
+open(my $CONNECTIONS_WAIT, "netstat -tulnap | grep CLOSE_WAIT | sed -e 's/::ffff://g' | awk '{print \$4,\$5}' | sed 's/:/ /g' |") || die "Failed: $!\n";
 
 while ( my $conn = <$CONNECTIONS_WAIT> )
 {


### PR DESCRIPTION
IPv6 socket that is used for IPv4 communication adds nasty header to netstat output.
This breaks the script:
  ffff 172.1.2.3 8085   ffff 172.1.2.4 59660
  ffff 172.1.2.3 8090   ffff 172.1.2.4 34530
  ffff 172.1.2.3 8092   ffff 172.1.2.4 56562

Strip off ipv6 header by adding extra sed expression "| sed -e 's/::ffff://g' |".
Now output looks like:
172.1.2.3 8085 172.1.2.4 59660
172.1.2.3 8090 172.1.2.4 34530
172.1.2.3 8092 172.1.2.4 56562